### PR TITLE
updated to write pre-training data as news.parquet

### DIFF
--- a/news-classification/README.md
+++ b/news-classification/README.md
@@ -36,6 +36,7 @@ train a text classifier
   - `relevant`: boolean indicator for article presence in the manually approved set.
 - writes "import.log", which captures some summary characteristics of the data as well as a few reports for transparency.
 - creates but does not write "merged.parquet", the combined dataframe representing all 3 snapshots from basedash.
+    - writes a subset of merged to "news.parquet" to use in pre-training
 - with `make_report(df, col)`, can generate a summary of `col`'s prevalence in keyword matched and relevant data. A sample report using `extracted_keywords` is generated with train-test data.
 
 ### Columns added/modified

--- a/news-classification/import/Makefile
+++ b/news-classification/import/Makefile
@@ -7,15 +7,16 @@
 news_included := input/news_articles_matchedsentence.csv.gz
 news_true := input/news_articles_matchedsentence_officers.csv.gz
 news_text := input/news_articles_newsarticle.csv.gz
+output := output/news.parquet
 
-.PHONY: all clean output
+.PHONY: all clean
 
-all: output
+all: $(output)
 
 clean: 
 	-rm -r output/*
 
-output: \
+$(output): \
 		src/import.py \
 		$(news_included) \
 		$(news_true) \
@@ -25,5 +26,6 @@ output: \
 		--included=$(news_included) \
 		--true=$(news_true) \
 		--text=$(news_text) \
+		--output=$@
 
 # done.

--- a/news-classification/import/note/.ipynb_checkpoints/import-checkpoint.ipynb
+++ b/news-classification/import/note/.ipynb_checkpoints/import-checkpoint.ipynb
@@ -9,7 +9,36 @@
     "# dependencies\n",
     "from numpy import nan as nan\n",
     "import pandas as pd\n",
-    "from sklearn.model_selection import train_test_split"
+    "from sklearn.model_selection import train_test_split\n",
+    "from math import ceil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "\"['title'] not in index\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/j_/497vxglx1kz07md2f3v37jlw0000gn/T/ipykernel_1828/978192088.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmerged\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloc\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m'article_id'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'title'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'content'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    923\u001b[0m                 \u001b[0;32mwith\u001b[0m \u001b[0msuppress\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mKeyError\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIndexError\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    924\u001b[0m                     \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_value\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtakeable\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_takeable\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 925\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_tuple\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    926\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    927\u001b[0m             \u001b[0;31m# we by definition only have the 0th axis\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_getitem_tuple\u001b[0;34m(self, tup)\u001b[0m\n\u001b[1;32m   1107\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_multi_take\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtup\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1108\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1109\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_tuple_same_dim\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtup\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1110\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1111\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_get_label\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabel\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_getitem_tuple_same_dim\u001b[0;34m(self, tup)\u001b[0m\n\u001b[1;32m    804\u001b[0m                 \u001b[0;32mcontinue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    805\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 806\u001b[0;31m             \u001b[0mretval\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mretval\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_axis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    807\u001b[0m             \u001b[0;31m# We should never have retval.ndim < self.ndim, as that should\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    808\u001b[0m             \u001b[0;31m#  be handled by the _getitem_lowerdim call above.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1151\u001b[0m                     \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Cannot index with multidimensional key\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1152\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1153\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_iterable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1154\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1155\u001b[0m             \u001b[0;31m# nested tuple slicing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_getitem_iterable\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1091\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1092\u001b[0m         \u001b[0;31m# A collection of keys\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1093\u001b[0;31m         \u001b[0mkeyarr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_listlike_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1094\u001b[0m         return self.obj._reindex_with_indexers(\n\u001b[1;32m   1095\u001b[0m             \u001b[0;34m{\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mallow_dups\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_get_listlike_indexer\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1312\u001b[0m             \u001b[0mkeyarr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnew_indexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0max\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_reindex_non_unique\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1313\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1314\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_validate_read_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkeyarr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mindexer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1315\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1316\u001b[0m         if needs_i8_conversion(ax.dtype) or isinstance(\n",
+      "\u001b[0;32m~/opt/anaconda3/lib/python3.9/site-packages/pandas/core/indexing.py\u001b[0m in \u001b[0;36m_validate_read_indexer\u001b[0;34m(self, key, indexer, axis)\u001b[0m\n\u001b[1;32m   1375\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1376\u001b[0m             \u001b[0mnot_found\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mensure_index\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmissing_mask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnonzero\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munique\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1377\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"{not_found} not in index\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1378\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1379\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: \"['title'] not in index\""
+     ]
+    }
+   ],
+   "source": [
+    "merged.loc[:, ['article_id', 'title', 'content']]"
    ]
   },
   {
@@ -45,12 +74,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# support methods\n",
     "def get_args():\n",
     "    parser = argparse.ArgumentParser()\n",
-    "    parser.add_argument(\"--included\", default='input/news_articles_matchedsentence.csv.gz')\n",
-    "    parser.add_argument(\"--true\", default='input/news_articles_matchedsentence_officers.csv.gz')\n",
-    "    parser.add_argument(\"--text\", default='input/news_articles_newsarticle.csv.gz')\n",
+    "    parser.add_argument(\"--included\")\n",
+    "    parser.add_argument(\"--true\")\n",
+    "    parser.add_argument(\"--text\")\n",
     "    parser.add_argument(\"--output\")\n",
     "    return parser.parse_args()\n",
     "\n",
@@ -66,14 +94,18 @@
     "    return pd.read_csv(f, compression='gzip')\n",
     "\n",
     "\n",
-    "def pretty_print(label, val, newline=False):\n",
-    "    print('{:50}{}'.format(label, val))\n",
+    "def pretty_str(label, a, b=False, newline=False):\n",
     "    if newline:\n",
-    "        print()\n",
+    "        if not b:\n",
+    "            return '{:50}{}{}'.format(label, a, '\\n')\n",
+    "        else:\n",
+    "            return '{:50}{:10}{:10}{}'.format(label, a, b, '\\n')\n",
+    "    if b:\n",
+    "        return '{:50}{:10}{:10}'.format(label, a, b)\n",
+    "    return '{:50}{}'.format(label, a)\n",
     "\n",
     "\n",
     "def check_asserts(text_df, sen_df, true_df):\n",
-    "    # asserts first\n",
     "    assert text_df.shape == (29707, 12)\n",
     "    assert sen_df.shape == (10470, 7)\n",
     "    assert true_df.shape == (735, 3)\n",
@@ -108,17 +140,6 @@
     "    assert len(true_match_sen) == 479\n",
     "    for match in true_match_sen:\n",
     "        assert match in matched_sen\n",
-    "    #reporting/logging second\n",
-    "    print('                overview of input')\n",
-    "    print('=======================================================')\n",
-    "    pretty_print('raw article data:', text_df.shape)\n",
-    "    pretty_print('matched kw data:', sen_df.shape)\n",
-    "    pretty_print('relevant sentence/officer data:', true_df.shape)\n",
-    "    pretty_print('unique articles:', len(articles))\n",
-    "    pretty_print('unique articles w/ kw match:', len(matched))\n",
-    "    pretty_print('unique matched sentences:', len(matched_sen))\n",
-    "    pretty_print('unique matched sentences relevant:', len(true_match_sen))\n",
-    "    pretty_print('unique matched officers relevant:', len(true_match_off))\n",
     "\n",
     "\n",
     "def format_extracted_str(list_str):\n",
@@ -131,7 +152,7 @@
     "\n",
     "\n",
     "def prep_dfs(text_df, sen_df, true_df):\n",
-    "    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'content']]\n",
+    "    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'title', 'content']]\n",
     "    temp = less_text\n",
     "    less_text = temp.rename(columns={'id':'article_id'})\n",
     "    less_sen = sen_df.loc[:, ['id', 'article_id', 'text']]\n",
@@ -160,56 +181,6 @@
     "    return out\n",
     "\n",
     "\n",
-    "# Per TS, starting train/test size should be 500/100\n",
-    "# ASSUMPTION: A 50/50 POS/NEG balance for model is reasonable starting point\n",
-    "# This method builds the POSITIVE cases: keyword matched AND article relevant (per Rajiv)\n",
-    "def prep_pos_train_test(df, train_n=0.80, test_n=0.20):\n",
-    "    id_mask = (df.officer_id.notnull())\n",
-    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
-    "    train_list, test_list = train_test_split(possible, test_size=test_n, train_size=train_n, shuffle=True)\n",
-    "    assert set(train_list).isdisjoint(set(test_list))\n",
-    "    return train_list, test_list\n",
-    "\n",
-    "\n",
-    "# This method builds the NEGATIVE cases: keyword matched but not relevant\n",
-    "def prep_neg_train_test(df, train_n=250, test_n=50):\n",
-    "    id_mask = (df.kw_match == 1) & (df.officer_id.isnull())\n",
-    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
-    "    train_list, test_list = train_test_split(possible, test_size=test_n, train_size=train_n, shuffle=True)\n",
-    "    assert set(train_list).isdisjoint(set(test_list))\n",
-    "    return train_list, test_list\n",
-    "\n",
-    "\n",
-    "def remake_merged(train_df, test_df, rem_df):\n",
-    "    l_df = train_df.copy()\n",
-    "    l_df['train'] = [1 for val in range(train_df.shape[0])]\n",
-    "    r_df = test_df.copy()\n",
-    "    r_df['test'] = [1 for val in range(test_df.shape[0])]    \n",
-    "    train_test_df = pd.concat([l_df, r_df])\n",
-    "    out = pd.concat([train_test_df, rem_df])\n",
-    "    out.train.fillna(value=0, axis=0, inplace=True)\n",
-    "    out.test.fillna(value=0, axis=0, inplace=True)\n",
-    "    temp = out\n",
-    "    out['train'] = temp.train.astype(int)\n",
-    "    out['test'] = temp.test.astype(int)\n",
-    "    return out\n",
-    "\n",
-    "\n",
-    "def make_train_test_cols(df):\n",
-    "    copy = df.copy()\n",
-    "    # get pos/neg and train/test indice sets\n",
-    "    pos_train_idx, pos_test_idx = prep_pos_train_test(copy)\n",
-    "    neg_train_idx, neg_test_idx = prep_neg_train_test(copy)\n",
-    "    # train\n",
-    "    train_idx = pos_train_idx + neg_train_idx\n",
-    "    copy['train'] = [1 if val in train_idx else 0 for val in copy.article_id.values]\n",
-    "    # test\n",
-    "    test_idx = pos_test_idx + neg_test_idx\n",
-    "    copy['test'] = [1 if val in test_idx else 0 for val in copy.article_id.values]\n",
-    "    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'text', \\\n",
-    "                'content', 'officer_id', 'extracted_keywords', 'kw_match', 'relevant', 'train', 'test']]\n",
-    "\n",
-    "\n",
     "# this method is called when relevant_articles and irrelevant_articles are not disjoint sets\n",
     "# resolves conflict by upgrading all occurances of an article_id in relevant_articles to relevant\n",
     "# ie. a sentence from an article is matched to an officer and appears in matchedsentence_officers data\n",
@@ -222,12 +193,53 @@
     "    return copy\n",
     "\n",
     "\n",
+    "# This method builds the POSITIVE cases: keyword matched AND article relevant (per Rajiv)\n",
+    "def prep_pos_train_test(df, train_perc=0.80, test_perc=0.20):\n",
+    "    id_mask = (df.officer_id.notnull())\n",
+    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
+    "    train_list, test_list = train_test_split(possible, test_size=test_perc, train_size=train_perc, shuffle=True)\n",
+    "    assert set(train_list).isdisjoint(set(test_list))\n",
+    "    return train_list, test_list\n",
+    "\n",
+    "\n",
+    "# This method builds the NEGATIVE cases: keyword matched but not relevant\n",
+    "def prep_neg_train_test(df, pos_rate, curr_train_n, curr_test_n):\n",
+    "    assert 0 < pos_rate <= 0.5\n",
+    "    target_train = ceil(curr_train_n/pos_rate)\n",
+    "    target_test = ceil(curr_test_n/pos_rate)\n",
+    "    needed_train = target_train - curr_train_n\n",
+    "    needed_test = target_test - curr_test_n\n",
+    "    id_mask = (df.kw_match == 1) & (df.officer_id.isnull())\n",
+    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
+    "    assert needed_train + needed_test <= len(possible)\n",
+    "    train_list, test_list = train_test_split(possible, test_size=needed_test, train_size=needed_train, shuffle=True)\n",
+    "    assert set(train_list).isdisjoint(set(test_list))\n",
+    "    return train_list, test_list\n",
+    "\n",
+    "\n",
+    "def make_train_test_cols(df, pos_rate):\n",
+    "    copy = df.copy()\n",
+    "    # get pos/neg and train/test indice sets\n",
+    "    pos_train_idx, pos_test_idx = prep_pos_train_test(copy)\n",
+    "    neg_train_idx, neg_test_idx = prep_neg_train_test(copy, pos_rate, len(pos_train_idx), len(pos_test_idx))\n",
+    "    # train\n",
+    "    train_idx = pos_train_idx + neg_train_idx\n",
+    "    copy['train'] = [1 if val in train_idx else 0 for val in copy.article_id.values]\n",
+    "    # test\n",
+    "    test_idx = pos_test_idx + neg_test_idx\n",
+    "    copy['test'] = [1 if val in test_idx else 0 for val in copy.article_id.values]\n",
+    "    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'title', 'text', \\\n",
+    "                'content', 'officer_id', 'extracted_keywords', 'kw_match', 'relevant', 'train', 'test']]\n",
+    "\n",
+    "\n",
     "def make_train_test_df(df):\n",
     "    full = df.loc[((df.train == 1) | (df.test == 1)), ['article_id', 'content', 'relevant', 'test']]\n",
     "    full.drop_duplicates(subset='article_id', inplace=True)\n",
     "    return full\n",
     "\n",
     "\n",
+    "# Since out.kw_match = out.relevant_count + out.irrelevant_count, and relevant can't be true without kw_match,\n",
+    "# (out.relevant_count) / (out.kw_match) should be the proportion of relevant samples given kw_match for col value\n",
     "def make_report(df, col):\n",
     "    kw_match_vc = df.loc[df.kw_match == 1][col].value_counts().to_dict()\n",
     "    relevant_vc = df.loc[df.relevant == 1][col].value_counts().to_dict()\n",
@@ -244,8 +256,22 @@
     "        else:\n",
     "            out_data[kw]['relevant_count'] = 0\n",
     "    out = pd.DataFrame.from_dict(out_data).T.reset_index().rename(columns={'index':col})\n",
-    "    out['relevant_perc'] = round((out.relevant_count) / (out.relevant_count + out.kw_match), 3)\n",
-    "    return out"
+    "    out['relevant_perc'] = round((out.relevant_count) / (out.kw_match), 3)\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def make_final_logs(text_df, sen_df, true_df, train_test_df, merged):\n",
+    "    logging.info('I/O id summary')\n",
+    "    logging.info('=======================================================================')\n",
+    "    logging.info(pretty_str('all kw_match articles in raw data:', True))      # asserted by check_asserts()\n",
+    "    logging.info(pretty_str('all matchedsentences in kw_match data:', True))\n",
+    "    logging.info(pretty_str('unique articles:', len(text_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique articles w/ kw match:', len(sen_df.article_id.unique())))\n",
+    "    logging.info(pretty_str('unique matched sentences:', len(sen_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique matched sentences relevant:', len(true_df.matchedsentence_id.unique())))\n",
+    "    logging.info(pretty_str('unique matched officers relevant:', len(true_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique articles in train_test:', len(train_test_df.article_id.unique()), newline=True))\n",
+    "    return 1"
    ]
   },
   {
@@ -274,16 +300,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                overview of input\n",
-      "=======================================================\n",
-      "raw article data:                                 (29707, 12)\n",
-      "matched kw data:                                  (10470, 7)\n",
-      "relevant sentence/officer data:                   (735, 3)\n",
-      "unique articles:                                  29707\n",
-      "unique articles w/ kw match:                      4323\n",
-      "unique matched sentences:                         10470\n",
-      "unique matched sentences relevant:                479\n",
-      "unique matched officers relevant:                 355\n",
       "unique relevant articles:                         316\n",
       "unique irrelevant articles:                       29616\n",
       "relevant and irrelevant disjoint:                 False\n",
@@ -322,18 +338,18 @@
     "rel_vals = relevant_articles.union(irrelevant_articles)\n",
     "assert all_ids.difference(rel_vals) == set()\n",
     "overlap = relevant_articles.intersection(irrelevant_articles)\n",
-    "pretty_print('unique relevant articles:', len(relevant_articles))\n",
-    "pretty_print('unique irrelevant articles:', len(irrelevant_articles))\n",
+    "print(pretty_str('unique relevant articles:', len(relevant_articles)))\n",
+    "print(pretty_str('unique irrelevant articles:', len(irrelevant_articles)))\n",
     "# check for conflicting 'relevant' values, correct if present\n",
-    "pretty_print('relevant and irrelevant disjoint:', overlap == set())\n",
+    "print(pretty_str('relevant and irrelevant disjoint:', overlap == set()))\n",
     "if overlap != set():\n",
-    "    pretty_print('size of overlap:', len(overlap))\n",
+    "    print(pretty_str('size of overlap:', len(overlap)))\n",
     "    temp = merged\n",
     "    merged = correct_relevant(temp)\n",
-    "    pretty_print('amended relevant column:', True)\n",
+    "    print(pretty_str('amended relevant column:', True))\n",
     "\n",
     "# proceed with generating training data\n",
-    "merged = make_train_test_cols(merged)\n",
+    "merged = make_train_test_cols(merged, pos_rate=0.50)\n",
     "train_test_df = make_train_test_df(merged)\n",
     "\n",
     "# generate source_id, author, keyword, reports\n",
@@ -350,29 +366,197 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.15"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Reviewing output data"
+    "# Estimated true pos_rate\n",
+    "kw_match_n = merged.loc[merged.kw_match==1].article_id.count()\n",
+    "relevant_n = merged.loc[merged.relevant==1].article_id.count()\n",
+    "round(relevant_n/kw_match_n, 2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (301042714.py, line 2)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  File \u001b[0;32m\"/var/folders/j_/497vxglx1kz07md2f3v37jlw0000gn/T/ipykernel_6542/301042714.py\"\u001b[0;36m, line \u001b[0;32m2\u001b[0m\n\u001b[0;31m    .7x\u001b[0m\n\u001b[0m      ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Are there any articles that contain a matched sentence but kw_match isn't True?\n",
+    "match = set(merged.loc[merged.kw_match == 1].article_id.unique())\n",
+    "no_match = set(merged.loc[merged.kw_match == 0].article_id.unique())\n",
+    "match.intersection(no_match)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n",
+      "(602, 4)\n",
+      "597\n"
      ]
     }
    ],
    "source": [
-    "x = 324234\n",
-    "print(f'{}')"
+    "# outgoing train_test asserts:\n",
+    "#    1. No article_id or content is missing from either train or test sets\n",
+    "#    2. No article_id or content appears in both train AND test sets\n",
+    "#    3. Every article_id has a relevant, test value\n",
+    "#    - Could assert pos_rate with margin of error +- 0.1\n",
+    "\n",
+    "# outgoing rule 1\n",
+    "assert train_test_df.loc[train_test_df.article_id.isnull()].shape == (0,4)\n",
+    "assert train_test_df.loc[train_test_df.content.isnull()].shape == (0,4)\n",
+    "\n",
+    "# outgoing rule 2\n",
+    "train_articles = set(train_test_df.loc[train_test_df.test == 0].article_id.unique())\n",
+    "test_articles = set(train_test_df.loc[train_test_df.test == 1].article_id.unique())\n",
+    "assert train_articles.isdisjoint(test_articles)\n",
+    "train_contents = set(train_test_df.loc[train_test_df.test == 0].content.unique())\n",
+    "test_contents = set(train_test_df.loc[train_test_df.test == 1].content.unique())\n",
+    "print(train_contents.isdisjoint(test_contents))\n",
+    "\n",
+    "# caveat to rule 2: duplicate \n",
+    "article_ids = set(train_test_df.article_id.unique())\n",
+    "contents = set(train_test_df.content.unique())\n",
+    "print(train_test_df.shape)\n",
+    "assert len(article_ids) == train_test_df.shape[0]\n",
+    "print(len(contents))\n",
+    "\n",
+    "# outgoing rule 3\n",
+    "assert train_test_df.loc[train_test_df.relevant.isnull()].shape == (0,4)\n",
+    "assert train_test_df.loc[train_test_df.test.isnull()].shape == (0,4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "duplicated content shape: (10, 4)\n",
+      "article_ids in train_test_df implicated by dup_content: 10\n",
+      "article_ids in merged implicated by dup_content: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rule 1 violation: Why is unique content < number of rows\n",
+    "dup_content = train_test_df.loc[train_test_df.duplicated(subset='content')].content.values.tolist()\n",
+    "if dup_content != []:\n",
+    "    dup_content_df = train_test_df.loc[train_test_df.content.isin(dup_content)]\n",
+    "    print('duplicated content shape:', dup_content_df.shape)\n",
+    "    dup_content_ids = dup_content_df.article_id.unique().tolist()\n",
+    "    print('article_ids in train_test_df implicated by dup_content:', len(dup_content_ids))\n",
+    "    all_dup_content_ids = merged.loc[merged.article_id.isin(dup_content_ids)].article_id.unique().tolist()\n",
+    "    print('article_ids in merged implicated by dup_content:', len(all_dup_content_ids))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "duplicate text shape:\t\t\t (26765, 12)\n",
+      "unique text samples duplicated:\t\t 580\n",
+      "articles affected by duplicate text:\t 410\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Are matchedsentence_ids unique by text, or by text in unique article?\n",
+    "dup_text = merged.loc[merged.duplicated(subset='text')].text.unique().tolist()\n",
+    "dup_text_df = merged.loc[merged.text.isin(dup_text)]\n",
+    "\n",
+    "dup_text_ids = {}\n",
+    "for tup in dup_text_df.itertuples():\n",
+    "    this_art_id = tup.article_id\n",
+    "    this_mat_id = tup.matchedsentence_id\n",
+    "    if str(tup.text) != 'nan':\n",
+    "        this_art_id = tup.article_id\n",
+    "        this_mat_id = tup.matchedsentence_id\n",
+    "        if tup.text not in dup_text_ids:\n",
+    "            dup_text_ids[tup.text] = {'article_id': [this_art_id], 'matchedsentence_id': [this_mat_id]}\n",
+    "        else:\n",
+    "            if this_art_id not in dup_text_ids[tup.text]['article_id']:\n",
+    "                dup_text_ids[tup.text]['article_id'].append(this_art_id)\n",
+    "            if this_mat_id not in dup_text_ids[tup.text]['matchedsentence_id']:\n",
+    "                dup_text_ids[tup.text]['matchedsentence_id'].append(this_mat_id)\n",
+    "\n",
+    "multiple_art = 0\n",
+    "for text, id_dict in dup_text_ids.items():\n",
+    "    if (len(id_dict['article_id']) > 1):\n",
+    "        multiple_art += 1\n",
+    "        # suspect sentences found in distinct articles are processed as distinct sentences\n",
+    "        # matchedsentence_id only refers to uniqueness within article, not in database\n",
+    "        assert len(id_dict['article_id']) == len(id_dict['matchedsentence_id'])\n",
+    "\n",
+    "print('duplicate text shape:\\t\\t\\t', dup_text_df.shape)\n",
+    "print('unique text samples duplicated:\\t\\t', len(dup_text_ids))\n",
+    "print('articles affected by duplicate text:\\t', text_mult_art)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Caddo Parish School announced Monday morning that Huntington High School will have an early release after power outage. Students will be released at 11 a.m. for pick up and bus release. Caddo Parish Schools said they are currently working with SWEPCO to restore power to the campus. SWEPCO estimates power will be restored later this afternoon. School will remain closed for the remainder of the day and will be in normal operation tomorrow. More:Shreveport Police Department officer terminated for violation of rules and regulations Makenzie Boucher is a reporter with the Shreveport Times. Contact her at mboucher@gannett.com.']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(merged.loc[merged.extracted_keywords == \"{'terminated', 'officer', 'police'}\"].content.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reviewing output data"
    ]
   },
   {

--- a/news-classification/import/note/import.ipynb
+++ b/news-classification/import/note/import.ipynb
@@ -9,7 +9,8 @@
     "# dependencies\n",
     "from numpy import nan as nan\n",
     "import pandas as pd\n",
-    "from sklearn.model_selection import train_test_split"
+    "from sklearn.model_selection import train_test_split\n",
+    "from math import ceil"
    ]
   },
   {
@@ -41,16 +42,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# support methods\n",
     "def get_args():\n",
     "    parser = argparse.ArgumentParser()\n",
-    "    parser.add_argument(\"--included\", default='input/news_articles_matchedsentence.csv.gz')\n",
-    "    parser.add_argument(\"--true\", default='input/news_articles_matchedsentence_officers.csv.gz')\n",
-    "    parser.add_argument(\"--text\", default='input/news_articles_newsarticle.csv.gz')\n",
+    "    parser.add_argument(\"--included\")\n",
+    "    parser.add_argument(\"--true\")\n",
+    "    parser.add_argument(\"--text\")\n",
     "    parser.add_argument(\"--output\")\n",
     "    return parser.parse_args()\n",
     "\n",
@@ -66,14 +66,18 @@
     "    return pd.read_csv(f, compression='gzip')\n",
     "\n",
     "\n",
-    "def pretty_print(label, val, newline=False):\n",
-    "    print('{:50}{}'.format(label, val))\n",
+    "def pretty_str(label, a, b=False, newline=False):\n",
     "    if newline:\n",
-    "        print()\n",
+    "        if not b:\n",
+    "            return '{:50}{}{}'.format(label, a, '\\n')\n",
+    "        else:\n",
+    "            return '{:50}{:10}{:10}{}'.format(label, a, b, '\\n')\n",
+    "    if b:\n",
+    "        return '{:50}{:10}{:10}'.format(label, a, b)\n",
+    "    return '{:50}{}'.format(label, a)\n",
     "\n",
     "\n",
     "def check_asserts(text_df, sen_df, true_df):\n",
-    "    # asserts first\n",
     "    assert text_df.shape == (29707, 12)\n",
     "    assert sen_df.shape == (10470, 7)\n",
     "    assert true_df.shape == (735, 3)\n",
@@ -108,17 +112,6 @@
     "    assert len(true_match_sen) == 479\n",
     "    for match in true_match_sen:\n",
     "        assert match in matched_sen\n",
-    "    #reporting/logging second\n",
-    "    print('                overview of input')\n",
-    "    print('=======================================================')\n",
-    "    pretty_print('raw article data:', text_df.shape)\n",
-    "    pretty_print('matched kw data:', sen_df.shape)\n",
-    "    pretty_print('relevant sentence/officer data:', true_df.shape)\n",
-    "    pretty_print('unique articles:', len(articles))\n",
-    "    pretty_print('unique articles w/ kw match:', len(matched))\n",
-    "    pretty_print('unique matched sentences:', len(matched_sen))\n",
-    "    pretty_print('unique matched sentences relevant:', len(true_match_sen))\n",
-    "    pretty_print('unique matched officers relevant:', len(true_match_off))\n",
     "\n",
     "\n",
     "def format_extracted_str(list_str):\n",
@@ -131,7 +124,7 @@
     "\n",
     "\n",
     "def prep_dfs(text_df, sen_df, true_df):\n",
-    "    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'content']]\n",
+    "    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'title', 'content']]\n",
     "    temp = less_text\n",
     "    less_text = temp.rename(columns={'id':'article_id'})\n",
     "    less_sen = sen_df.loc[:, ['id', 'article_id', 'text']]\n",
@@ -160,56 +153,6 @@
     "    return out\n",
     "\n",
     "\n",
-    "# Per TS, starting train/test size should be 500/100\n",
-    "# ASSUMPTION: A 50/50 POS/NEG balance for model is reasonable starting point\n",
-    "# This method builds the POSITIVE cases: keyword matched AND article relevant (per Rajiv)\n",
-    "def prep_pos_train_test(df, train_n=0.80, test_n=0.20):\n",
-    "    id_mask = (df.officer_id.notnull())\n",
-    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
-    "    train_list, test_list = train_test_split(possible, test_size=test_n, train_size=train_n, shuffle=True)\n",
-    "    assert set(train_list).isdisjoint(set(test_list))\n",
-    "    return train_list, test_list\n",
-    "\n",
-    "\n",
-    "# This method builds the NEGATIVE cases: keyword matched but not relevant\n",
-    "def prep_neg_train_test(df, train_n=250, test_n=50):\n",
-    "    id_mask = (df.kw_match == 1) & (df.officer_id.isnull())\n",
-    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
-    "    train_list, test_list = train_test_split(possible, test_size=test_n, train_size=train_n, shuffle=True)\n",
-    "    assert set(train_list).isdisjoint(set(test_list))\n",
-    "    return train_list, test_list\n",
-    "\n",
-    "\n",
-    "def remake_merged(train_df, test_df, rem_df):\n",
-    "    l_df = train_df.copy()\n",
-    "    l_df['train'] = [1 for val in range(train_df.shape[0])]\n",
-    "    r_df = test_df.copy()\n",
-    "    r_df['test'] = [1 for val in range(test_df.shape[0])]    \n",
-    "    train_test_df = pd.concat([l_df, r_df])\n",
-    "    out = pd.concat([train_test_df, rem_df])\n",
-    "    out.train.fillna(value=0, axis=0, inplace=True)\n",
-    "    out.test.fillna(value=0, axis=0, inplace=True)\n",
-    "    temp = out\n",
-    "    out['train'] = temp.train.astype(int)\n",
-    "    out['test'] = temp.test.astype(int)\n",
-    "    return out\n",
-    "\n",
-    "\n",
-    "def make_train_test_cols(df):\n",
-    "    copy = df.copy()\n",
-    "    # get pos/neg and train/test indice sets\n",
-    "    pos_train_idx, pos_test_idx = prep_pos_train_test(copy)\n",
-    "    neg_train_idx, neg_test_idx = prep_neg_train_test(copy)\n",
-    "    # train\n",
-    "    train_idx = pos_train_idx + neg_train_idx\n",
-    "    copy['train'] = [1 if val in train_idx else 0 for val in copy.article_id.values]\n",
-    "    # test\n",
-    "    test_idx = pos_test_idx + neg_test_idx\n",
-    "    copy['test'] = [1 if val in test_idx else 0 for val in copy.article_id.values]\n",
-    "    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'text', \\\n",
-    "                'content', 'officer_id', 'extracted_keywords', 'kw_match', 'relevant', 'train', 'test']]\n",
-    "\n",
-    "\n",
     "# this method is called when relevant_articles and irrelevant_articles are not disjoint sets\n",
     "# resolves conflict by upgrading all occurances of an article_id in relevant_articles to relevant\n",
     "# ie. a sentence from an article is matched to an officer and appears in matchedsentence_officers data\n",
@@ -222,12 +165,53 @@
     "    return copy\n",
     "\n",
     "\n",
+    "# This method builds the POSITIVE cases: keyword matched AND article relevant (per Rajiv)\n",
+    "def prep_pos_train_test(df, train_perc=0.80, test_perc=0.20):\n",
+    "    id_mask = (df.officer_id.notnull())\n",
+    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
+    "    train_list, test_list = train_test_split(possible, test_size=test_perc, train_size=train_perc, shuffle=True)\n",
+    "    assert set(train_list).isdisjoint(set(test_list))\n",
+    "    return train_list, test_list\n",
+    "\n",
+    "\n",
+    "# This method builds the NEGATIVE cases: keyword matched but not relevant\n",
+    "def prep_neg_train_test(df, pos_rate, curr_train_n, curr_test_n):\n",
+    "    assert 0 < pos_rate <= 0.5\n",
+    "    target_train = ceil(curr_train_n/pos_rate)\n",
+    "    target_test = ceil(curr_test_n/pos_rate)\n",
+    "    needed_train = target_train - curr_train_n\n",
+    "    needed_test = target_test - curr_test_n\n",
+    "    id_mask = (df.kw_match == 1) & (df.officer_id.isnull())\n",
+    "    possible = df.loc[id_mask].article_id.unique().tolist()\n",
+    "    assert needed_train + needed_test <= len(possible)\n",
+    "    train_list, test_list = train_test_split(possible, test_size=needed_test, train_size=needed_train, shuffle=True)\n",
+    "    assert set(train_list).isdisjoint(set(test_list))\n",
+    "    return train_list, test_list\n",
+    "\n",
+    "\n",
+    "def make_train_test_cols(df, pos_rate):\n",
+    "    copy = df.copy()\n",
+    "    # get pos/neg and train/test indice sets\n",
+    "    pos_train_idx, pos_test_idx = prep_pos_train_test(copy)\n",
+    "    neg_train_idx, neg_test_idx = prep_neg_train_test(copy, pos_rate, len(pos_train_idx), len(pos_test_idx))\n",
+    "    # train\n",
+    "    train_idx = pos_train_idx + neg_train_idx\n",
+    "    copy['train'] = [1 if val in train_idx else 0 for val in copy.article_id.values]\n",
+    "    # test\n",
+    "    test_idx = pos_test_idx + neg_test_idx\n",
+    "    copy['test'] = [1 if val in test_idx else 0 for val in copy.article_id.values]\n",
+    "    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'title', 'text', \\\n",
+    "                'content', 'officer_id', 'extracted_keywords', 'kw_match', 'relevant', 'train', 'test']]\n",
+    "\n",
+    "\n",
     "def make_train_test_df(df):\n",
     "    full = df.loc[((df.train == 1) | (df.test == 1)), ['article_id', 'content', 'relevant', 'test']]\n",
     "    full.drop_duplicates(subset='article_id', inplace=True)\n",
     "    return full\n",
     "\n",
     "\n",
+    "# Since out.kw_match = out.relevant_count + out.irrelevant_count, and relevant can't be true without kw_match,\n",
+    "# (out.relevant_count) / (out.kw_match) should be the proportion of relevant samples given kw_match for col value\n",
     "def make_report(df, col):\n",
     "    kw_match_vc = df.loc[df.kw_match == 1][col].value_counts().to_dict()\n",
     "    relevant_vc = df.loc[df.relevant == 1][col].value_counts().to_dict()\n",
@@ -244,8 +228,22 @@
     "        else:\n",
     "            out_data[kw]['relevant_count'] = 0\n",
     "    out = pd.DataFrame.from_dict(out_data).T.reset_index().rename(columns={'index':col})\n",
-    "    out['relevant_perc'] = round((out.relevant_count) / (out.relevant_count + out.kw_match), 3)\n",
-    "    return out"
+    "    out['relevant_perc'] = round((out.relevant_count) / (out.kw_match), 3)\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def make_final_logs(text_df, sen_df, true_df, train_test_df, merged):\n",
+    "    logging.info('I/O id summary')\n",
+    "    logging.info('=======================================================================')\n",
+    "    logging.info(pretty_str('all kw_match articles in raw data:', True))      # asserted by check_asserts()\n",
+    "    logging.info(pretty_str('all matchedsentences in kw_match data:', True))\n",
+    "    logging.info(pretty_str('unique articles:', len(text_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique articles w/ kw match:', len(sen_df.article_id.unique())))\n",
+    "    logging.info(pretty_str('unique matched sentences:', len(sen_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique matched sentences relevant:', len(true_df.matchedsentence_id.unique())))\n",
+    "    logging.info(pretty_str('unique matched officers relevant:', len(true_df.id.unique())))\n",
+    "    logging.info(pretty_str('unique articles in train_test:', len(train_test_df.article_id.unique()), newline=True))\n",
+    "    return 1"
    ]
   },
   {
@@ -267,23 +265,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                overview of input\n",
-      "=======================================================\n",
-      "raw article data:                                 (29707, 12)\n",
-      "matched kw data:                                  (10470, 7)\n",
-      "relevant sentence/officer data:                   (735, 3)\n",
-      "unique articles:                                  29707\n",
-      "unique articles w/ kw match:                      4323\n",
-      "unique matched sentences:                         10470\n",
-      "unique matched sentences relevant:                479\n",
-      "unique matched officers relevant:                 355\n",
       "unique relevant articles:                         316\n",
       "unique irrelevant articles:                       29616\n",
       "relevant and irrelevant disjoint:                 False\n",
@@ -322,18 +310,18 @@
     "rel_vals = relevant_articles.union(irrelevant_articles)\n",
     "assert all_ids.difference(rel_vals) == set()\n",
     "overlap = relevant_articles.intersection(irrelevant_articles)\n",
-    "pretty_print('unique relevant articles:', len(relevant_articles))\n",
-    "pretty_print('unique irrelevant articles:', len(irrelevant_articles))\n",
+    "print(pretty_str('unique relevant articles:', len(relevant_articles)))\n",
+    "print(pretty_str('unique irrelevant articles:', len(irrelevant_articles)))\n",
     "# check for conflicting 'relevant' values, correct if present\n",
-    "pretty_print('relevant and irrelevant disjoint:', overlap == set())\n",
+    "print(pretty_str('relevant and irrelevant disjoint:', overlap == set()))\n",
     "if overlap != set():\n",
-    "    pretty_print('size of overlap:', len(overlap))\n",
+    "    print(pretty_str('size of overlap:', len(overlap)))\n",
     "    temp = merged\n",
     "    merged = correct_relevant(temp)\n",
-    "    pretty_print('amended relevant column:', True)\n",
+    "    print(pretty_str('amended relevant column:', True))\n",
     "\n",
     "# proceed with generating training data\n",
-    "merged = make_train_test_cols(merged)\n",
+    "merged = make_train_test_cols(merged, pos_rate=0.50)\n",
     "train_test_df = make_train_test_df(merged)\n",
     "\n",
     "# generate source_id, author, keyword, reports\n",
@@ -341,12 +329,194 @@
     "author_report = make_report(merged, 'author')\n",
     "kw_report = make_report(merged, 'extracted_keywords')\n",
     "\n",
-    "# save outputs\n",
-    "train_test_df.to_parquet('../output/train-test.parquet')\n",
-    "#news.to_parquet('../output/news.parquet')\n",
-    "#src_report.to_parquet('../output/source_report.parquet')\n",
-    "#author_report.to_parquet('../output/author_report.parquet')\n",
-    "#kw_report.to_parquet('../output/keyword_report.parquet')"
+    "# save outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.15"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Estimated true pos_rate\n",
+    "kw_match_n = merged.loc[merged.kw_match==1].article_id.count()\n",
+    "relevant_n = merged.loc[merged.relevant==1].article_id.count()\n",
+    "round(relevant_n/kw_match_n, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "set()"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Are there any articles that contain a matched sentence but kw_match isn't True?\n",
+    "match = set(merged.loc[merged.kw_match == 1].article_id.unique())\n",
+    "no_match = set(merged.loc[merged.kw_match == 0].article_id.unique())\n",
+    "match.intersection(no_match)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "False\n",
+      "(602, 4)\n",
+      "597\n"
+     ]
+    }
+   ],
+   "source": [
+    "# outgoing train_test asserts:\n",
+    "#    1. No article_id or content is missing from either train or test sets\n",
+    "#    2. No article_id or content appears in both train AND test sets\n",
+    "#    3. Every article_id has a relevant, test value\n",
+    "#    - Could assert pos_rate with margin of error +- 0.1\n",
+    "\n",
+    "# outgoing rule 1\n",
+    "assert train_test_df.loc[train_test_df.article_id.isnull()].shape == (0,4)\n",
+    "assert train_test_df.loc[train_test_df.content.isnull()].shape == (0,4)\n",
+    "\n",
+    "# outgoing rule 2\n",
+    "train_articles = set(train_test_df.loc[train_test_df.test == 0].article_id.unique())\n",
+    "test_articles = set(train_test_df.loc[train_test_df.test == 1].article_id.unique())\n",
+    "assert train_articles.isdisjoint(test_articles)\n",
+    "train_contents = set(train_test_df.loc[train_test_df.test == 0].content.unique())\n",
+    "test_contents = set(train_test_df.loc[train_test_df.test == 1].content.unique())\n",
+    "print(train_contents.isdisjoint(test_contents))\n",
+    "\n",
+    "# caveat to rule 2: duplicate \n",
+    "article_ids = set(train_test_df.article_id.unique())\n",
+    "contents = set(train_test_df.content.unique())\n",
+    "print(train_test_df.shape)\n",
+    "assert len(article_ids) == train_test_df.shape[0]\n",
+    "print(len(contents))\n",
+    "\n",
+    "# outgoing rule 3\n",
+    "assert train_test_df.loc[train_test_df.relevant.isnull()].shape == (0,4)\n",
+    "assert train_test_df.loc[train_test_df.test.isnull()].shape == (0,4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "duplicated content shape: (10, 4)\n",
+      "article_ids in train_test_df implicated by dup_content: 10\n",
+      "article_ids in merged implicated by dup_content: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rule 1 violation: Why is unique content < number of rows\n",
+    "dup_content = train_test_df.loc[train_test_df.duplicated(subset='content')].content.values.tolist()\n",
+    "if dup_content != []:\n",
+    "    dup_content_df = train_test_df.loc[train_test_df.content.isin(dup_content)]\n",
+    "    print('duplicated content shape:', dup_content_df.shape)\n",
+    "    dup_content_ids = dup_content_df.article_id.unique().tolist()\n",
+    "    print('article_ids in train_test_df implicated by dup_content:', len(dup_content_ids))\n",
+    "    all_dup_content_ids = merged.loc[merged.article_id.isin(dup_content_ids)].article_id.unique().tolist()\n",
+    "    print('article_ids in merged implicated by dup_content:', len(all_dup_content_ids))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "duplicate text shape:\t\t\t (26765, 12)\n",
+      "unique text samples duplicated:\t\t 580\n",
+      "articles affected by duplicate text:\t 410\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Are matchedsentence_ids unique by text, or by text in unique article?\n",
+    "dup_text = merged.loc[merged.duplicated(subset='text')].text.unique().tolist()\n",
+    "dup_text_df = merged.loc[merged.text.isin(dup_text)]\n",
+    "\n",
+    "dup_text_ids = {}\n",
+    "for tup in dup_text_df.itertuples():\n",
+    "    this_art_id = tup.article_id\n",
+    "    this_mat_id = tup.matchedsentence_id\n",
+    "    if str(tup.text) != 'nan':\n",
+    "        this_art_id = tup.article_id\n",
+    "        this_mat_id = tup.matchedsentence_id\n",
+    "        if tup.text not in dup_text_ids:\n",
+    "            dup_text_ids[tup.text] = {'article_id': [this_art_id], 'matchedsentence_id': [this_mat_id]}\n",
+    "        else:\n",
+    "            if this_art_id not in dup_text_ids[tup.text]['article_id']:\n",
+    "                dup_text_ids[tup.text]['article_id'].append(this_art_id)\n",
+    "            if this_mat_id not in dup_text_ids[tup.text]['matchedsentence_id']:\n",
+    "                dup_text_ids[tup.text]['matchedsentence_id'].append(this_mat_id)\n",
+    "\n",
+    "multiple_art = 0\n",
+    "for text, id_dict in dup_text_ids.items():\n",
+    "    if (len(id_dict['article_id']) > 1):\n",
+    "        multiple_art += 1\n",
+    "        # suspect sentences found in distinct articles are processed as distinct sentences\n",
+    "        # matchedsentence_id only refers to uniqueness within article, not in database\n",
+    "        assert len(id_dict['article_id']) == len(id_dict['matchedsentence_id'])\n",
+    "\n",
+    "print('duplicate text shape:\\t\\t\\t', dup_text_df.shape)\n",
+    "print('unique text samples duplicated:\\t\\t', len(dup_text_ids))\n",
+    "print('articles affected by duplicate text:\\t', text_mult_art)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Caddo Parish School announced Monday morning that Huntington High School will have an early release after power outage. Students will be released at 11 a.m. for pick up and bus release. Caddo Parish Schools said they are currently working with SWEPCO to restore power to the campus. SWEPCO estimates power will be restored later this afternoon. School will remain closed for the remainder of the day and will be in normal operation tomorrow. More:Shreveport Police Department officer terminated for violation of rules and regulations Makenzie Boucher is a reporter with the Shreveport Times. Contact her at mboucher@gannett.com.']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(merged.loc[merged.extracted_keywords == \"{'terminated', 'officer', 'police'}\"].content.values)"
    ]
   },
   {

--- a/news-classification/import/src/import.py
+++ b/news-classification/import/src/import.py
@@ -91,7 +91,7 @@ def format_extracted_str(list_str):
 
 
 def prep_dfs(text_df, sen_df, true_df):
-    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'content']]
+    less_text = text_df.loc[:, ['id', 'source_id', 'author', 'title', 'content']]
     temp = less_text
     less_text = temp.rename(columns={'id':'article_id'})
     less_sen = sen_df.loc[:, ['id', 'article_id', 'text']]
@@ -167,7 +167,7 @@ def make_train_test_cols(df, pos_rate):
     # test
     test_idx = pos_test_idx + neg_test_idx
     copy['test'] = [1 if val in test_idx else 0 for val in copy.article_id.values]
-    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'text', \
+    return copy[['article_id', 'matchedsentence_id', 'source_id', 'author', 'title', 'text', \
                 'content', 'officer_id', 'extracted_keywords', 'kw_match', 'relevant', 'train', 'test']]
 
 
@@ -295,6 +295,11 @@ if __name__ == '__main__':
     test.info()
     print()
 
+    # writing a subset of merged to use as pre-training data
+    temp = merged.loc[:, ['article_id', 'title', 'content']].drop_duplicates(subset='article_id')
+    assert len(temp.article_id.unique()) == temp.shape[0]
+    news = temp.sample(temp.shape[0]).reset_index(drop=True)
+    
     assert make_final_logs(text_df, sen_df, true_df, train_test_df, merged)
     
     # generate keyword report (source_id, author also helpful reports)
@@ -309,6 +314,7 @@ if __name__ == '__main__':
     # save output(s)
     train.to_parquet('output/train.parquet')
     test.to_parquet('output/test.parquet')
+    news.to_parquet(output_f)
     logging.info("done.")
     
 # done.


### PR DESCRIPTION
- "import/makefile" actually writes news.parquet
- "import/src/import.py"
    - creates news dataframe with columns `['article_id', 'title', 'content']`
    - drops duplicate article_ids, shuffles rows, writes file
    - NOTE: `df.sample()` currently uses n=news.shape[0] so all of the unique articles in merged database are written, including those in train-test data
- "README.md" updated to reflect changes in output written